### PR TITLE
remove rotated-0 from .cell.flipped

### DIFF
--- a/src/Cell.css
+++ b/src/Cell.css
@@ -53,7 +53,7 @@
   transform: rotate(270deg) scaleX(-1);
 } */
 
-.cell.flipped.rotated-0 {
+.cell.flipped {
   transform: rotate(0deg) scaleX(-1);
 }
 .cell.flipped.rotated-90 {


### PR DESCRIPTION
because it's not part of the class when tile 6 gets flipped, as also when it is not flipped

The div-Tag for a flipped and not rotated tile 6 
```
<div class="cell tile available flipped track track-6"></div>
```
